### PR TITLE
Fix setting locale failed issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,9 @@ RUN \
   useradd -u ${UID} -g go -d /home/go -m go && \
   echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list && \
   apt-get update && \
-  apt-get install -y git subversion mercurial openssh-client bash unzip curl && \
+  apt-get install -y git subversion mercurial openssh-client bash unzip curl locales && \
   apt-get autoclean && \
+  echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && /usr/sbin/locale-gen && \
   curl --fail --location --silent --show-error https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz > openjdk-bin.tar.gz && \
   mkdir -p /go-agent/jre && \
   tar -xf openjdk-bin.tar.gz -C /go-agent/jre --strip 1 --exclude "jdk*/lib/src.zip" --exclude "jdk*/include" --exclude "jdk*/jmods" && \


### PR DESCRIPTION
I‘ve open a issue https://github.com/gocd/docker-gocd-agent/issues/88

This pull request will set the locale for the go-agent image, 

```
root@3519fd2a5386:/# locale
LANG=en_US.utf8
LANGUAGE=
LC_CTYPE="en_US.utf8"
LC_NUMERIC="en_US.utf8"
LC_TIME="en_US.utf8"
LC_COLLATE="en_US.utf8"
LC_MONETARY="en_US.utf8"
LC_MESSAGES="en_US.utf8"
LC_PAPER="en_US.utf8"
LC_NAME="en_US.utf8"
LC_ADDRESS="en_US.utf8"
LC_TELEPHONE="en_US.utf8"
LC_MEASUREMENT="en_US.utf8"
LC_IDENTIFICATION="en_US.utf8"
LC_ALL=
```

Then the gradle problem `Malformed input or input contains unmappable characters` will be solved.